### PR TITLE
Note subjects are editable via network PUT request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /coverage
 /.nyc_output
+debug.log

--- a/src/api/route/note.js
+++ b/src/api/route/note.js
@@ -17,8 +17,10 @@ module.exports.get = async (req, res) => {
 };
 
 module.exports.update = async (req, res) => {
-    await req.note.update(req.body);
-    res.json(req.note.expose());
+    if(!req.body.subject) {
+        await req.note.update(req.body);
+        res.json(req.note.expose());
+    }
 };
 
 module.exports.delete = async (req, res) => {

--- a/test/api/route/note.test.js
+++ b/test/api/route/note.test.js
@@ -86,6 +86,17 @@ describe('Tests for api route note', () => {
             req.note.update.calledWithExactly(req.body).should.be.true();
             res.json.calledWithExactly('exposedNote').should.be.true();
         });
+        it('should not update the note if the subject is a part of the update request', async() => {
+            req.note = note
+            req.body = {
+                subject: 'test subject'
+            }
+
+            await route.note.update(req, res);
+            req.note.update.calledWithExactly(req.body).should.be.false();
+            res.json.calledWithExactly('exposedNote').should.be.false();
+
+        })
     });
 
     describe('delete', () => {


### PR DESCRIPTION
Notes are able to be updated via PUT requests to the API, despite the fact that the application tries to prohibit this behavior. This is because the ```route.note.update``` method is taking the whole req.body object as a parameter without checking the object's contents.

To reproduce this bug, 

1.  Create a note
2.  Note the ID of the note you just created in the Chrome dev tools Network pane
![image](https://user-images.githubusercontent.com/18550934/86503648-707a7e80-bdf3-11ea-8bec-90276e498630.png)
The note should have the subject you created:

3. Run a network request using fetch to the web API
```
await fetch('http://localhost:7428/api/notes/3', {
    method: 'PUT',
    headers: {
      'Content-Type': 'application/json'
    },
    body: JSON.stringify({'subject': 'Subject edit!'})
})
```
4. The subject should be edited on the server.

It indicates that if other more sensitive data is added or passed through, it's vulnerable to the same issues or if a malicious third party acted as a man-in-the-middle, they could change data before it reaches the server. Additionally, remote code execution could be possible due to being able to enter information in an unvalidated, unsanitised manner.

I feel the reasons this bug can be allowed to exist could be in part due to the way the Factory is set up in ```public/resources/note.js```. The use of an update function in ```route/note.js``` to call the update on the ```req.note``` object. It's not as simple to validate on the $resource object in the Factory function.

I considered building a piece of middleware to run on the edit route. While this would've been a discrete, testable and repeatable piece of code that can be imported and used anywhere, I ultimately felt it was too big a change for just one element of an update function.

The reason I selected the if statement is because of it's simplicity and semantic correctness.  However if something were to go wrong, the if statement could skip past the critical update function. Ultimately though, an if statement vs a piece of middleware that could fail and block another more important process seemed like a worthy tradeoff in terms of utility, safety and effort.



